### PR TITLE
Fix glfw high dpi retina

### DIFF
--- a/modules/brl/gametarget.cxs
+++ b/modules/brl/gametarget.cxs
@@ -45,6 +45,9 @@ Class BBGame Extends Null
 	
 	Method GetDeviceWidth:Int()
 	Method GetDeviceHeight:Int()
+	Method GetFramebufferWidth:Int() ' At the moment this is only needed for GLFW on HighDPI Displays like Retina.
+	Method GetFramebufferHeight:Int()
+	
 	Method SetDeviceWindow:Void( Width:Int,Height:Int,Flags:Int )
 	Method SetDeviceWindowIcon:Void( _path:String )
 	Method SetDeviceWindowPosition:Void( _x:Int, _y:Int )

--- a/modules/brl/native/gametarget.cpp
+++ b/modules/brl/native/gametarget.cpp
@@ -70,6 +70,8 @@ public:
 	
 	virtual int GetDeviceWidth(){ return 0; }
 	virtual int GetDeviceHeight(){ return 0; }
+	virtual int GetFramebufferWidth(){ return 0; }
+	virtual int GetFramebufferHeight(){ return 0; }
 	virtual void SetDeviceWindow( int width,int height,int flags ){}
 	virtual void SetDeviceWindowIcon( String _path ){}
 	virtual void SetDeviceWindowPosition( int _x, int _y ){}

--- a/modules/brl/native/gametarget.cpp
+++ b/modules/brl/native/gametarget.cpp
@@ -70,8 +70,8 @@ public:
 	
 	virtual int GetDeviceWidth(){ return 0; }
 	virtual int GetDeviceHeight(){ return 0; }
-	virtual int GetFramebufferWidth(){ return 0; }
-	virtual int GetFramebufferHeight(){ return 0; }
+	virtual int GetFramebufferWidth(){ return this->GetDeviceWidth(); }
+	virtual int GetFramebufferHeight(){ return this->GetDeviceHeight(); }
 	virtual void SetDeviceWindow( int width,int height,int flags ){}
 	virtual void SetDeviceWindowIcon( String _path ){}
 	virtual void SetDeviceWindowPosition( int _x, int _y ){}

--- a/modules/brl/native/gametarget.cs
+++ b/modules/brl/native/gametarget.cs
@@ -161,6 +161,14 @@ public class BBGame{
 	public virtual int GetDeviceHeight(){
 		return 0;
 	}
+
+	public virtual int GetFramebufferWidth(){
+		return this.GetDeviceWidth();
+	}
+	
+	public virtual int GetFramebufferHeight(){
+		return this.GetDeviceHeight();
+	}
 	
 	public virtual void SetDeviceWindow( int width,int height,int flags ){
 	}

--- a/modules/brl/native/gametarget.java
+++ b/modules/brl/native/gametarget.java
@@ -158,6 +158,14 @@ abstract class BBGame{
 	int GetDeviceHeight(){
 		return 0;
 	}
+
+	int GetFramebufferWidth(){
+		return this.GetDeviceWidth();
+	}
+	
+	int GetFramebufferHeight(){
+		return this.GetDeviceHeight();
+	}
 	
 	void SetDeviceWindow( int width,int height,int flags ){
 	}

--- a/modules/brl/native/gametarget.js
+++ b/modules/brl/native/gametarget.js
@@ -152,6 +152,14 @@ BBGame.prototype.GetDeviceHeight=function(){
 	return 0;
 }
 
+BBGame.prototype.GetFramebufferWidth=function(){
+	return this.GetDeviceWidth();
+}
+
+BBGame.prototype.GetFramebufferHeight=function(){
+	return this.GetDeviceHeight();
+}
+
 BBGame.prototype.SetDeviceWindow=function( width,height,flags ){
 }
 

--- a/modules/mojo/app.cxs
+++ b/modules/mojo/app.cxs
@@ -55,7 +55,7 @@ End
 
 Function ValidateDeviceWindow:Void( notifyApp:Bool )
 	Print("App.cxs:ValidateDeviceWindow")
-'	Local w:=_game.GetDeviceWindowWidth()
+	Local w:=_game.GetDeviceWindowWidth()
 '	Local h:=_game.GetDeviceWindowHeight()
 	Local w:=_game.GetDeviceWidth()
 	Local h:=_game.GetDeviceHeight()

--- a/modules/mojo/app.cxs
+++ b/modules/mojo/app.cxs
@@ -25,6 +25,8 @@ Global _game:=BBGame.Game()
 Global _delegate:GameDelegate
 Global _devWidth:Int
 Global _devHeight:Int
+Global _framebufWidth:Int
+Global _framebufHeight:Int
 Global _updateRate:Int
 Global _displayModes:DisplayMode[]
 Global _desktopMode:DisplayMode
@@ -55,13 +57,16 @@ End
 
 Function ValidateDeviceWindow:Void( notifyApp:Bool )
 	Print("App.cxs:ValidateDeviceWindow")
-'	Local w:=_game.GetDeviceWindowWidth()
-'	Local h:=_game.GetDeviceWindowHeight()
+	Local fbW:=_game.GetFramebufferWidth()
+	Print("fbW = " + fbW)
+	Local fbH:=_game.GetFramebufferHeight()
 	Local w:=_game.GetDeviceWidth()
 	Local h:=_game.GetDeviceHeight()
-	If w=_devWidth And h=_devHeight Return
+	If w=_devWidth And h=_devHeight And fbW = _framebufWidth And fbH = _framebufHeight Return
 	_devWidth=w
 	_devHeight=h
+	_framebufWidth = fbW
+	_framebufHeight = fbH
 	If notifyApp _app.OnResize
 End
 	
@@ -274,6 +279,14 @@ End
 
 Function DeviceHeight:Int()
 	Return _devHeight
+End
+
+Function FramebufferWidth:Int()
+	Return _framebufWidth
+End
+
+Function FramebufferHeight:Int()
+	Return _framebufHeight
 End
 
 Function SetDeviceWindow:Void( width:Int,height:Int,flags:Int )

--- a/modules/mojo/app.cxs
+++ b/modules/mojo/app.cxs
@@ -54,6 +54,9 @@ Function EnumDisplayModes:Void()
 End
 
 Function ValidateDeviceWindow:Void( notifyApp:Bool )
+	Print("App.cxs:ValidateDeviceWindow")
+'	Local w:=_game.GetDeviceWindowWidth()
+'	Local h:=_game.GetDeviceWindowHeight()
 	Local w:=_game.GetDeviceWidth()
 	Local h:=_game.GetDeviceHeight()
 	If w=_devWidth And h=_devHeight Return

--- a/modules/mojo/app.cxs
+++ b/modules/mojo/app.cxs
@@ -55,7 +55,7 @@ End
 
 Function ValidateDeviceWindow:Void( notifyApp:Bool )
 	Print("App.cxs:ValidateDeviceWindow")
-	Local w:=_game.GetDeviceWindowWidth()
+'	Local w:=_game.GetDeviceWindowWidth()
 '	Local h:=_game.GetDeviceWindowHeight()
 	Local w:=_game.GetDeviceWidth()
 	Local h:=_game.GetDeviceHeight()

--- a/modules/mojo/app.cxs
+++ b/modules/mojo/app.cxs
@@ -56,9 +56,9 @@ Function EnumDisplayModes:Void()
 End
 
 Function ValidateDeviceWindow:Void( notifyApp:Bool )
-	Print("App.cxs:ValidateDeviceWindow")
+	'Print("App.cxs:ValidateDeviceWindow")
 	Local fbW:=_game.GetFramebufferWidth()
-	Print("fbW = " + fbW)
+	'Print("fbW = " + fbW)
 	Local fbH:=_game.GetFramebufferHeight()
 	Local w:=_game.GetDeviceWidth()
 	Local h:=_game.GetDeviceHeight()

--- a/modules/mojo/native/mojo.glfw.cpp
+++ b/modules/mojo/native/mojo.glfw.cpp
@@ -203,11 +203,9 @@ int gxtkGraphics::BeginRender(){
 	
 	width=height=0;
 #ifdef _glfw3_h_
-	//glfwGetWindowSize( BBGlfwGame::GlfwGame()->GetGLFWwindow(),&width,&height );
-	//glfwGetFramebufferSize( BBGlfwGame::GlfwGame()->GetGLFWwindow(),&width, &height );
 	width = BBGlfwGame::GlfwGame()->GetDeviceWidth();
 	height = BBGlfwGame::GlfwGame()->GetDeviceHeight();
-	bbPrint(String("mojo.glfw.cpp:GetDeviceWidth()") + width);
+	//bbPrint(String("mojo.glfw.cpp:GetDeviceWidth()") + width);
 	fbWidth = BBGlfwGame::GlfwGame()->GetFramebufferWidth();
 	fbHeight = BBGlfwGame::GlfwGame()->GetFramebufferHeight();
 #else

--- a/modules/mojo/native/mojo.glfw.cpp
+++ b/modules/mojo/native/mojo.glfw.cpp
@@ -204,7 +204,10 @@ int gxtkGraphics::BeginRender(){
 	width=height=0;
 #ifdef _glfw3_h_
 	//glfwGetWindowSize( BBGlfwGame::GlfwGame()->GetGLFWwindow(),&width,&height );
-	glfwGetFramebufferSize( BBGlfwGame::GlfwGame()->GetGLFWwindow(),&width, &height );
+	//glfwGetFramebufferSize( BBGlfwGame::GlfwGame()->GetGLFWwindow(),&width, &height );
+	width = BBGlfwGame::GlfwGame()->GetDeviceWidth();
+	bbPrint(width);
+	height = BBGlfwGame::GlfwGame()->GetDeviceHeight();
 #else
 	glfwGetWindowSize( &width,&height );
 #endif

--- a/modules/mojo/native/mojo.glfw.cpp
+++ b/modules/mojo/native/mojo.glfw.cpp
@@ -198,16 +198,18 @@ int gxtkGraphics::Height(){
 }
 
 int gxtkGraphics::BeginRender(){
-	//int newWidth = 0;
-	//int newHeight = 0;
+	int fbWidth = 0;
+	int fbHeight = 0;
 	
 	width=height=0;
 #ifdef _glfw3_h_
 	//glfwGetWindowSize( BBGlfwGame::GlfwGame()->GetGLFWwindow(),&width,&height );
 	//glfwGetFramebufferSize( BBGlfwGame::GlfwGame()->GetGLFWwindow(),&width, &height );
 	width = BBGlfwGame::GlfwGame()->GetDeviceWidth();
-	bbPrint(width);
 	height = BBGlfwGame::GlfwGame()->GetDeviceHeight();
+	bbPrint(String("mojo.glfw.cpp:GetDeviceWidth()") + width);
+	fbWidth = BBGlfwGame::GlfwGame()->GetFramebufferWidth();
+	fbHeight = BBGlfwGame::GlfwGame()->GetFramebufferHeight();
 #else
 	glfwGetWindowSize( &width,&height );
 #endif
@@ -216,8 +218,7 @@ int gxtkGraphics::BeginRender(){
 	return 0;
 #else
 
-	glViewport( 0,0,width,height );
-	//glViewport( 0,0,newWidth,newHeight );
+	glViewport( 0,0,fbWidth, fbHeight );
 
 	glMatrixMode( GL_PROJECTION );
 	glLoadIdentity();

--- a/modules/mojo/native/mojo.glfw.cpp
+++ b/modules/mojo/native/mojo.glfw.cpp
@@ -18,9 +18,10 @@ public:
 
 	int width;
 	int height;
+	
 	int fbWidth = 0;
 	int fbHeight = 0;
-
+	float highDPI_Factor = 1.0; // Needed to ensure proper scaling if #GLFW_HIGH_DPI_ENABLED is false.
 
 	int colorARGB;
 	float r,g,b,alpha;
@@ -210,6 +211,7 @@ int gxtkGraphics::BeginRender(){
 	//bbPrint(String("mojo.glfw.cpp:GetDeviceWidth()") + width);
 	fbWidth = BBGlfwGame::GlfwGame()->GetFramebufferWidth();
 	fbHeight = BBGlfwGame::GlfwGame()->GetFramebufferHeight();
+	highDPI_Factor = float(fbWidth) / float(width) ;
 #else
 	glfwGetWindowSize( &width,&height );
 #endif
@@ -306,10 +308,10 @@ int gxtkGraphics::SetScissor( int x,int y,int w,int h ){
 	
 	if( x!=0 || y!=0 || w!=Width() || h!=Height() ){
 		glEnable( GL_SCISSOR_TEST );
-		x*=2.0;
-		y*=2.0;
-		w*=2.0;
-		h*=2.0;
+		x*=highDPI_Factor;
+		y*=highDPI_Factor;
+		w*=highDPI_Factor;
+		h*=highDPI_Factor;
 		//y=Height()-y-h;
 		y=fbHeight-y-h;
 		glScissor( x,y,w,h );

--- a/modules/mojo/native/mojo.glfw.cpp
+++ b/modules/mojo/native/mojo.glfw.cpp
@@ -18,6 +18,9 @@ public:
 
 	int width;
 	int height;
+	int fbWidth = 0;
+	int fbHeight = 0;
+
 
 	int colorARGB;
 	float r,g,b,alpha;
@@ -73,6 +76,7 @@ public:
 	unsigned char *data;
 	int width;
 	int height;
+
 	int depth;
 	int format;
 	int seq;
@@ -198,9 +202,7 @@ int gxtkGraphics::Height(){
 }
 
 int gxtkGraphics::BeginRender(){
-	int fbWidth = 0;
-	int fbHeight = 0;
-	
+	fbWidth=fbHeight=0;	
 	width=height=0;
 #ifdef _glfw3_h_
 	width = BBGlfwGame::GlfwGame()->GetDeviceWidth();
@@ -304,7 +306,12 @@ int gxtkGraphics::SetScissor( int x,int y,int w,int h ){
 	
 	if( x!=0 || y!=0 || w!=Width() || h!=Height() ){
 		glEnable( GL_SCISSOR_TEST );
-		y=Height()-y-h;
+		x*=2.0;
+		y*=2.0;
+		w*=2.0;
+		h*=2.0;
+		//y=Height()-y-h;
+		y=fbHeight-y-h;
 		glScissor( x,y,w,h );
 	}else{
 		glDisable( GL_SCISSOR_TEST );

--- a/modules/mojo2/graphics.cxs
+++ b/modules/mojo2/graphics.cxs
@@ -2575,9 +2575,9 @@ Class Canvas Extends DrawList
 	Method SetRenderTarget:Void( target:Object )
 
 		FlushPrims
-		
+		Print("Setrendertarget()")
 		If Not target
-		
+			Print("Setrendertarget(Null)")
 			_image=Null
 			_texture=Null
 			_width=DeviceWidth
@@ -3064,17 +3064,17 @@ Class Canvas Extends DrawList
 			If Not _texture
 				_width=DeviceWidth
 				_height=DeviceHeight
-				_twidth=_width
-				_theight=_height
+				_twidth=_width*2  'Multiplied for test purpose! ********
+				_theight=_height*2  'Multiplied for test purpose! ********
 			Endif
 		
-			_vpx=_viewport[0];_vpy=_viewport[1];_vpw=_viewport[2];_vph=_viewport[3]
+			_vpx=_viewport[0];_vpy=_viewport[1];_vpw=_viewport[2]*2;_vph=_viewport[3]*2  'Multiplied for test purpose! ********
 			If _image
 				_vpx+=_image._x
 				_vpy+=_image._y
 			Endif
 			
-			_scx=_scissor[0];_scy=_scissor[1];_scw=_scissor[2];_sch=_scissor[3]
+			_scx=_scissor[0]*2;_scy=_scissor[1]*2;_scw=_scissor[2]*2;_sch=_scissor[3]*2  'Multiplied for test purpose! ********
 			
 			If _scx<0 _scx=0 Else If _scx>_vpw _scx=_vpw
 			If _scw<0 _scw=0 Else If _scx+_scw>_vpw _scw=_vpw-_scx
@@ -3088,7 +3088,7 @@ Class Canvas Extends DrawList
 				_vpy=_theight-_vpy-_vph
 				_scy=_theight-_scy-_sch
 			Endif
-			
+			Print("Dirty Viewport validate3091")
 			glViewport _vpx,_vpy,_vpw,_vph
 			
 			If _scx<>_vpx Or _scy<>_vpy Or _scw<>_vpw Or _sch<>_vph

--- a/modules/mojo2/graphics.cxs
+++ b/modules/mojo2/graphics.cxs
@@ -3088,9 +3088,9 @@ Class Canvas Extends DrawList
 				_vpy=_theight-_vpy-_vph
 				_scy=_theight-_scy-_sch
 			Endif
-			Print("validate:Dirty Viewport L3091")
-			Print(scale)
-			Print(_vpx + " " + _vpy + " " + _vpw + " " + _vph)
+			'Print("validate:Dirty Viewport L3091")
+			'Print(scale)
+			'Print(_vpx + " " + _vpy + " " + _vpw + " " + _vph)
 			glViewport _vpx,_vpy,_vpw,_vph
 			
 			If _scx<>_vpx Or _scy<>_vpy Or _scw<>_vpw Or _sch<>_vph

--- a/modules/mojo2/graphics.cxs
+++ b/modules/mojo2/graphics.cxs
@@ -2565,7 +2565,7 @@ Class Canvas Extends DrawList
 	Method New( target:Object=Null )
 		Init
 		SetRenderTarget target
-		SetViewport 0,0,_twidth,_theight
+		SetViewport 0,0,DeviceWidth(),DeviceHeight()
 		SetProjection2d 0,_width,0,_height
 	End
 	
@@ -3068,7 +3068,7 @@ Class Canvas Extends DrawList
 				scale = Float(_twidth) / Float(_width)
 			Endif
 		
-			_vpx=_viewport[0];_vpy=_viewport[1];_vpw=_viewport[2];_vph=_viewport[3]
+			_vpx=_viewport[0]*scale;_vpy=_viewport[1]*scale;_vpw=_viewport[2]*scale;_vph=_viewport[3]*scale
 			If _image
 				_vpx+=_image._x
 				_vpy+=_image._y
@@ -3088,7 +3088,9 @@ Class Canvas Extends DrawList
 				_vpy=_theight-_vpy-_vph
 				_scy=_theight-_scy-_sch
 			Endif
-			Print("Dirty Viewport validate3091")
+			Print("validate:Dirty Viewport L3091")
+			Print(scale)
+			Print(_vpx + " " + _vpy + " " + _vpw + " " + _vph)
 			glViewport _vpx,_vpy,_vpw,_vph
 			
 			If _scx<>_vpx Or _scy<>_vpy Or _scw<>_vpw Or _sch<>_vph

--- a/modules/mojo2/graphics.cxs
+++ b/modules/mojo2/graphics.cxs
@@ -2565,7 +2565,7 @@ Class Canvas Extends DrawList
 	Method New( target:Object=Null )
 		Init
 		SetRenderTarget target
-		SetViewport 0,0,_width,_height
+		SetViewport 0,0,_twidth,_theight
 		SetProjection2d 0,_width,0,_height
 	End
 	
@@ -2575,15 +2575,13 @@ Class Canvas Extends DrawList
 	Method SetRenderTarget:Void( target:Object )
 
 		FlushPrims
-		Print("Setrendertarget()")
 		If Not target
-			Print("Setrendertarget(Null)")
 			_image=Null
 			_texture=Null
 			_width=DeviceWidth
 			_height=DeviceHeight
-			_twidth=_width
-			_theight=_height
+			_twidth=FramebufferWidth
+			_theight=FramebufferHeight
 		
 		Else If Image( target )
 		
@@ -3060,21 +3058,23 @@ Class Canvas Extends DrawList
 		End
 		
 		If _dirty & DIRTY_VIEWPORT
-		
+			
+			Local scale:Float = 1.0
 			If Not _texture
 				_width=DeviceWidth
 				_height=DeviceHeight
-				_twidth=_width*2  'Multiplied for test purpose! ********
-				_theight=_height*2  'Multiplied for test purpose! ********
+				_twidth=FramebufferWidth  
+				_theight=FramebufferHeight  
+				scale = Float(_twidth) / Float(_width)
 			Endif
 		
-			_vpx=_viewport[0];_vpy=_viewport[1];_vpw=_viewport[2]*2;_vph=_viewport[3]*2  'Multiplied for test purpose! ********
+			_vpx=_viewport[0];_vpy=_viewport[1];_vpw=_viewport[2];_vph=_viewport[3]
 			If _image
 				_vpx+=_image._x
 				_vpy+=_image._y
 			Endif
 			
-			_scx=_scissor[0]*2;_scy=_scissor[1]*2;_scw=_scissor[2]*2;_sch=_scissor[3]*2  'Multiplied for test purpose! ********
+			_scx=_scissor[0]*scale;_scy=_scissor[1]*scale;_scw=_scissor[2]*scale;_sch=_scissor[3]*scale 
 			
 			If _scx<0 _scx=0 Else If _scx>_vpw _scx=_vpw
 			If _scw<0 _scw=0 Else If _scx+_scw>_vpw _scw=_vpw-_scx

--- a/targets/glfw3/modules/native/glfwgame.cpp
+++ b/targets/glfw3/modules/native/glfwgame.cpp
@@ -593,8 +593,8 @@ void BBGlfwGame::OnWindowClose( GLFWwindow *window ){
 }
 
 void BBGlfwGame::OnWindowSize( GLFWwindow *window,int width,int height ){
-	bbPrint(String("OnWinSize") + width);
-	bbPrint(_glfwGame->_width);
+	//bbPrint(String("OnWinSize") + width);
+	//bbPrint(_glfwGame->_width);
 	_glfwGame->_width=width;
 	_glfwGame->_height=height;
 	_glfwGame->SetHighDPI_Factor((double)(width) / (double)(_glfwGame->_width));
@@ -609,7 +609,7 @@ void BBGlfwGame::OnWindowSize( GLFWwindow *window,int width,int height ){
 
 
 void BBGlfwGame::OnFramebufferSize( GLFWwindow *window,int width,int height ){
-	bbPrint(String("OnFramebufferSize: ") + width);
+	//bbPrint(String("OnFramebufferSize: ") + width);
 	_glfwGame->_frameBufWidth=width;
 	_glfwGame->_frameBufHeight=height;
 	//bbPrint(_glfwGame->GetDeviceWidth());

--- a/targets/glfw3/modules/native/glfwgame.cpp
+++ b/targets/glfw3/modules/native/glfwgame.cpp
@@ -24,6 +24,9 @@ public:
 	virtual int GetDeviceHeight(){ return _height * _highDPI_Factor; }
 	virtual int GetDeviceWindowWidth(){ bbPrint(String("GetDeviceWindowWidth: ") + _width); return _width; }
 	virtual int GetDeviceWindowHeight(){ return _height; }
+	virtual int GetFramebufferWidth(){ bbPrint(String("GetFramebufferWidth: ") + float(_frameBufWidth)); return _frameBufWidth; }
+	virtual int GetFramebufferHeight(){ return _frameBufHeight; }
+
 
 	virtual void SetHighDPI_Factor(double newValue);
 	virtual void SetDeviceWindow( int width,int height,int flags );

--- a/targets/glfw3/modules/native/glfwgame.cpp
+++ b/targets/glfw3/modules/native/glfwgame.cpp
@@ -593,10 +593,12 @@ void BBGlfwGame::OnWindowClose( GLFWwindow *window ){
 }
 
 void BBGlfwGame::OnWindowSize( GLFWwindow *window,int width,int height ){
-	// bbPrint("OnWinSize");
-	// bbPrint(_glfwGame->_width);
+	bbPrint(String("OnWinSize") + width);
+	bbPrint(_glfwGame->_width);
 	_glfwGame->_width=width;
 	_glfwGame->_height=height;
+	_glfwGame->SetHighDPI_Factor((double)(width) / (double)(_glfwGame->_width));
+
 	
 #if CFG_GLFW_WINDOW_RENDER_WHILE_RESIZING && !__linux
 	_glfwGame->RenderGame();
@@ -607,7 +609,7 @@ void BBGlfwGame::OnWindowSize( GLFWwindow *window,int width,int height ){
 
 
 void BBGlfwGame::OnFramebufferSize( GLFWwindow *window,int width,int height ){
-	//bbPrint(String("OnFramebufferSize: ") + width);
+	bbPrint(String("OnFramebufferSize: ") + width);
 	_glfwGame->_frameBufWidth=width;
 	_glfwGame->_frameBufHeight=height;
 	//bbPrint(_glfwGame->GetDeviceWidth());

--- a/targets/glfw3/modules/native/glfwgame.cpp
+++ b/targets/glfw3/modules/native/glfwgame.cpp
@@ -20,11 +20,11 @@ public:
 	virtual void SetClipboard( String _text );
 	virtual String GetClipboard();
 	
-	virtual int GetDeviceWidth(){ bbPrint(String("GetDeviceWidth: ") + float(_width * _highDPI_Factor)); return _width * _highDPI_Factor; }
+	virtual int GetDeviceWidth(){ return _width * _highDPI_Factor; }
 	virtual int GetDeviceHeight(){ return _height * _highDPI_Factor; }
-	virtual int GetDeviceWindowWidth(){ bbPrint(String("GetDeviceWindowWidth: ") + _width); return _width; }
+	virtual int GetDeviceWindowWidth(){ return _width; }
 	virtual int GetDeviceWindowHeight(){ return _height; }
-	virtual int GetFramebufferWidth(){ bbPrint(String("GetFramebufferWidth: ") + float(_frameBufWidth)); return _frameBufWidth; }
+	virtual int GetFramebufferWidth(){ return _frameBufWidth; }
 	virtual int GetFramebufferHeight(){ return _frameBufHeight; }
 
 
@@ -593,8 +593,8 @@ void BBGlfwGame::OnWindowClose( GLFWwindow *window ){
 }
 
 void BBGlfwGame::OnWindowSize( GLFWwindow *window,int width,int height ){
-	bbPrint("OnWinSize");
-	bbPrint(_glfwGame->_width);
+	// bbPrint("OnWinSize");
+	// bbPrint(_glfwGame->_width);
 	_glfwGame->_width=width;
 	_glfwGame->_height=height;
 	
@@ -607,10 +607,10 @@ void BBGlfwGame::OnWindowSize( GLFWwindow *window,int width,int height ){
 
 
 void BBGlfwGame::OnFramebufferSize( GLFWwindow *window,int width,int height ){
-	bbPrint(String("OnFramebufferSize: ") + width);
+	//bbPrint(String("OnFramebufferSize: ") + width);
 	_glfwGame->_frameBufWidth=width;
 	_glfwGame->_frameBufHeight=height;
-	bbPrint(_glfwGame->GetDeviceWidth());
+	//bbPrint(_glfwGame->GetDeviceWidth());
 	_glfwGame->SetHighDPI_Factor((double)(width) / (double)(_glfwGame->_width));
 }
 
@@ -632,7 +632,6 @@ String BBGlfwGame::GetClipboard(){
 
 
 void BBGlfwGame::SetHighDPI_Factor(double factor){
-	
 	#if !CFG_GLFW_HIGH_DPI_ENABLED
 		factor = 1.0;
 	#endif

--- a/targets/glfw3/modules/native/glfwgame.cpp
+++ b/targets/glfw3/modules/native/glfwgame.cpp
@@ -597,9 +597,8 @@ void BBGlfwGame::OnWindowSize( GLFWwindow *window,int width,int height ){
 	//bbPrint(_glfwGame->_width);
 	_glfwGame->_width=width;
 	_glfwGame->_height=height;
-	_glfwGame->SetHighDPI_Factor((double)(width) / (double)(_glfwGame->_width));
+	_glfwGame->SetHighDPI_Factor((double)(_glfwGame->_frameBufWidth) / (double)(width));
 
-	
 #if CFG_GLFW_WINDOW_RENDER_WHILE_RESIZING && !__linux
 	_glfwGame->RenderGame();
 	glfwSwapBuffers( _glfwGame->_window );


### PR DESCRIPTION
I introduced a config constant #GLFW_HIGH_DPI_ENABLED to make the usage of the whole resolution possible (=1) while keeping old fashioned apps running as usual (=0), which is the default setting so far. 

I guess this fix is not ready for merging as I expect some issues with other targets than glfw and there might be problems when using stuff like setviewport or setscissors and getting the values later.
But for testing it should be fine.