### PR TITLE
Tween should end with perfect 1.0

### DIFF
--- a/modules/brl/tween.cxs
+++ b/modules/brl/tween.cxs
@@ -172,7 +172,11 @@ Class Tween
 		End
 
 		x = time/Float(duration)
-		value = GetTween(x)		
+		if time=duration
+			value = 1.0
+		else
+			value = GetTween(x)	
+		endif		
 	End
 
 	Method GetTween:Float(t:Float)


### PR DESCRIPTION
When tween ended, the value sometime not a perfect 1.0.
When we apply to object position for example, it not in perfect place.