### PR TITLE
DrawImage9P bug & rotate issue

### DIFF
--- a/modules/mojo/graphics.cxs
+++ b/modules/mojo/graphics.cxs
@@ -841,17 +841,24 @@ Function DrawImage9P( image:Image, x#,y#,patchSize, rotation#, scaleX#,scaleY#,f
 	Rotate rotation
 	Translate xo2, yo2
 
-	DrawImageRect ( image,0,0, 0,0,patchSize,patchSize, frame )
-	_DrawImageRect2( image,patchSize-image.HandleX,-image.HandleY,patchSize,0,image.Width-patchS2,patchSize,0.0,tsX,1.0, frame )
-	DrawImageRect ( image,(image.Width*scaleX)-patchSize,0,image.Width-patchSize,0,patchSize,patchSize, frame )
+	'20220416 - edit by Mag. [-]miss position of vertical left/right bar on Y scale. [+] add extra pixel to eliminate black antialias that showup when rotation apply
+	
+	'draw centre part first
+	_DrawImageRect2( image,patchSize-image.HandleX,patchSize-image.HandleY,patchSize,patchSize,image.Width()-patchS2,image.Height()-patchS2,0,tsX, tsY, frame ) 'centre part
 
-	DrawImageRect( image,0,patchSize, 0,patchSize,patchSize,image.Height-patchS2,0.0, 1.0,tsY, frame )
-	_DrawImageRect2( image,patchSize-image.HandleX,patchSize-image.HandleY,patchSize,patchSize,image.Width()-patchS2,image.Height()-patchS2,0,tsX, tsY, frame )
-	DrawImageRect( image,(image.Width*scaleX)-patchSize,patchSize, image.Width-patchSize,patchSize,patchSize,image.Height-patchS2,0.0, 1.0,tsY, frame )
+	'draw harizontal top/bottom bar on to of centre part above
+	_DrawImageRect2( image,patchSize-image.HandleX,-image.HandleY,patchSize,0,image.Width-patchS2,patchSize+tsY,0.0,tsX,1.0, frame ) 'top part
+	_DrawImageRect2( image,patchSize-image.HandleX       , image.Height*scaleY-patchSize-image.HandleY-tsY, patchSize ,image.Height-patchSize-tsY,image.Width-patchS2,patchSize+tsY,0,tsX,1.0, frame ) 'bottom part
 
-	DrawImageRect ( image,0                             , image.Height*scaleY-patchSize, 0,image.Height-patchSize,patchSize,patchSize, frame )
-	_DrawImageRect2( image,patchSize-image.HandleX       , image.Height*scaleY-patchSize-image.HandleY, patchSize ,image.Height-patchSize,image.Width-patchS2,patchSize,0,tsX,1.0, frame )
-	DrawImageRect ( image,(image.Width*scaleX)-patchSize, image.Height*scaleY-patchSize, image.Width-patchSize,image.Height-patchSize, patchSize,patchSize, frame )
+	'draw left/right vertical abr on to of all part above
+	DrawImageRect( image,0,(patchS2*tsY)-patchSize, 0,patchSize,patchSize+tsX,image.Height-patchS2,0.0, 1.0,tsY, frame ) 'leftbar
+	DrawImageRect( image,(image.Width*scaleX)-patchSize-tsX,(patchS2*tsY)-patchSize, image.Width-patchSize-tsX,patchSize,patchSize+tsX,image.Height-patchS2,0.0, 1.0,tsY, frame )'rightbar
+
+	'draw angle part on to of all part above
+	DrawImageRect ( image,0,0, 0,0,patchSize+tsX,patchSize+tsY, frame ) 'top left
+	DrawImageRect ( image,(image.Width*scaleX)-patchSize-tsX,0,image.Width-patchSize-tsX,0,patchSize+tsX,patchSize+tsX, frame ) 'top right
+	DrawImageRect ( image,0                             , image.Height*scaleY-patchSize-tsY, 0,image.Height-patchSize-tsY,patchSize+tsX,patchSize+tsY, frame ) 'bottomleft
+	DrawImageRect ( image,(image.Width*scaleX)-patchSize-tsX, image.Height*scaleY-patchSize-tsY, image.Width-patchSize-tsX,image.Height-patchSize-tsY, patchSize+tsX,patchSize+tsY, frame ) 'bottomright
 
 	PopMatrix
 End


### PR DESCRIPTION
Base on https://www.cerberus-x.com/community/index.php?threads/drawimage9p-bug-rotate-issue.1611/
[-]miss position of vertical left/right bar on Y scale.
[+] add an extra pixel to eliminate black antialias that show up when rotation apply