### PR TITLE
Fix config var separator character not working for AndroidManifest

### DIFF
--- a/examples/test_apps/Config Settings/config_settings_test.cxs
+++ b/examples/test_apps/Config Settings/config_settings_test.cxs
@@ -1,0 +1,53 @@
+Strict 
+
+Import mojo
+
+'This CONFIG_LOGGING_ENABLED variable is just a reminder 
+'for an idea to create a logging file to check all 
+'resulting app config vars.
+'#CONFIG_LOGGING_ENABLED = True 
+
+
+#Rem
+#ANDROID_MANIFEST_APPLICATION+="<bla>"
+#ANDROID_MANIFEST_APPLICATION+="<bla>"
+#ANDROID_MANIFEST_APPLICATION+="~n~t <bla>"
+#ANDROID_MANIFEST_APPLICATION+="~n~t <bla>"
+#End
+
+
+Function Main:Int()
+    New ConfigSettingsTest()
+    Return 0
+End
+
+
+Class ConfigSettingsTest Extends App
+	
+	Field rotation:Float
+	
+    Method OnCreate:Int()
+		Print "Here we test again..."
+    	Return 0
+    End
+    
+    
+    Method OnUpdate:Int()
+    	rotation+=2.0
+		Return 0
+    End
+    
+    
+    Method OnRender:Int()
+    
+    	Cls()
+    	
+    	PushMatrix()
+      	Translate(DeviceWidth()*0.5, DeviceHeight()*0.5)
+	  	Rotate(-rotation)
+    	DrawRect(-100,-100, 200, 200)
+    	PopMatrix()
+    	Return 0
+    End
+
+End

--- a/src/transcc/builders/android.cxs
+++ b/src/transcc/builders/android.cxs
@@ -50,12 +50,18 @@ Class AndroidBuilder Extends Builder
 		SetEnv "ANDROID_SDK_DIR",tcc.ANDROID_PATH.Replace( "\","\\" )
         SetEnv "ANDROID_NDK_DIR",tcc.ANDROID_NDK_PATH.Replace( "\","\\" )
 		
-		SetConfigVar "ANDROID_LIBRARY_REFERENCE_1",GetConfigVar( "ANDROID_LIBRARY_REFERENCE_1" ).Replace( ";","~n" )+"~n"
-		SetConfigVar "ANDROID_LIBRARY_REFERENCE_2",GetConfigVar( "ANDROID_LIBRARY_REFERENCE_2" ).Replace( ";","~n" )+"~n"
-		
-		SetConfigVar "ANDROID_MANIFEST_MAIN",GetConfigVar( "ANDROID_MANIFEST_MAIN" ).Replace( ";","~n" )+"~n"
-		Local manifest:String = GetConfigVar( "ANDROID_MANIFEST_APPLICATION" ).Replace( ";","~n" )+"~n"
-
+        Local ref1:String = GetConfigVar( "ANDROID_LIBRARY_REFERENCE_1" )
+        Local ref2:String = GetConfigVar( "ANDROID_LIBRARY_REFERENCE_2" )
+        Local manifest:String = GetConfigVar( "ANDROID_MANIFEST_APPLICATION" )
+     
+        If ref1.Contains( ";" ) then ref1=ref1.Replace( ";","~n" )+"~n" Else ref1=ref1.Replace( "|","~n" )+"~n"
+        If ref2.Contains( ";" ) then ref2=ref2.Replace( ";","~n" )+"~n" Else ref2=ref2.Replace( "|","~n" )+"~n"
+        If manifest.Contains( ";" ) then manifest=manifest.Replace( ";","~n" )+"~n" Else manifest=manifest.Replace( "|","~n" )+"~n"
+     
+        SetConfigVar "ANDROID_LIBRARY_REFERENCE_1",ref1
+        SetConfigVar "ANDROID_LIBRARY_REFERENCE_2",ref2
+        SetConfigVar "ANDROID_MANIFEST_MAIN",manifest
+        
 		Local admob_appid:=GetConfigVar( "ADMOB_ANDROID_ADS_APPID" )
 		If admob_appid.Length()>0 Then 
 			Local admob_appid2:String = "<meta-data android:name=~qcom.google.android.gms.ads.APPLICATION_ID~q "

--- a/src/transcc/transcc.build/cpptool/main.cpp
+++ b/src/transcc/transcc.build/cpptool/main.cpp
@@ -12,7 +12,7 @@
 #define CFG_CONFIG release
 #define CFG_CPP_DOUBLE_PRECISION_FLOATS 1
 #define CFG_CPP_GC_MODE 1
-#define CFG_HOST linux
+#define CFG_HOST macos
 #define CFG_LANG cpp
 #define CFG_MODPATH 
 #define CFG_RELEASE 1
@@ -18812,7 +18812,7 @@ String c_TransCC::p_GetReleaseVersion(){
 }
 void c_TransCC::p_Run(Array<String > t_args){
 	gc_assign(this->m_args,t_args);
-	bbPrint(String(L"TRANS cerberus compiler V2023-04-06",35));
+	bbPrint(String(L"TRANS cerberus compiler V2023-07-08",35));
 	m_cerberusdir=GetEnv(String(L"CERBERUS_DIR",12));
 	m__libs=m_cerberusdir+String(L"/libs/",6);
 	SetEnv(String(L"CERBERUSDIR",11),m_cerberusdir);
@@ -20863,10 +20863,27 @@ void c_AndroidBuilder::p_MakeTarget(){
 	String t_app_package=bb_config_GetConfigVar(String(L"ANDROID_APP_PACKAGE",19));
 	SetEnv(String(L"ANDROID_SDK_DIR",15),m_tcc->m_ANDROID_PATH.Replace(String(L"\\",1),String(L"\\\\",2)));
 	SetEnv(String(L"ANDROID_NDK_DIR",15),m_tcc->m_ANDROID_NDK_PATH.Replace(String(L"\\",1),String(L"\\\\",2)));
-	bb_config_SetConfigVar2(String(L"ANDROID_LIBRARY_REFERENCE_1",27),bb_config_GetConfigVar(String(L"ANDROID_LIBRARY_REFERENCE_1",27)).Replace(String(L";",1),String(L"\n",1))+String(L"\n",1));
-	bb_config_SetConfigVar2(String(L"ANDROID_LIBRARY_REFERENCE_2",27),bb_config_GetConfigVar(String(L"ANDROID_LIBRARY_REFERENCE_2",27)).Replace(String(L";",1),String(L"\n",1))+String(L"\n",1));
-	bb_config_SetConfigVar2(String(L"ANDROID_MANIFEST_MAIN",21),bb_config_GetConfigVar(String(L"ANDROID_MANIFEST_MAIN",21)).Replace(String(L";",1),String(L"\n",1))+String(L"\n",1));
-	String t_manifest=bb_config_GetConfigVar(String(L"ANDROID_MANIFEST_APPLICATION",28)).Replace(String(L";",1),String(L"\n",1))+String(L"\n",1);
+	String t_ref1=bb_config_GetConfigVar(String(L"ANDROID_LIBRARY_REFERENCE_1",27));
+	String t_ref2=bb_config_GetConfigVar(String(L"ANDROID_LIBRARY_REFERENCE_2",27));
+	String t_manifest=bb_config_GetConfigVar(String(L"ANDROID_MANIFEST_APPLICATION",28));
+	if(t_ref1.Contains(String(L";",1))){
+		t_ref1=t_ref1.Replace(String(L";",1),String(L"\n",1))+String(L"\n",1);
+	}else{
+		t_ref1=t_ref1.Replace(String(L"|",1),String(L"\n",1))+String(L"\n",1);
+	}
+	if(t_ref2.Contains(String(L";",1))){
+		t_ref2=t_ref2.Replace(String(L";",1),String(L"\n",1))+String(L"\n",1);
+	}else{
+		t_ref2=t_ref2.Replace(String(L"|",1),String(L"\n",1))+String(L"\n",1);
+	}
+	if(t_manifest.Contains(String(L";",1))){
+		t_manifest=t_manifest.Replace(String(L";",1),String(L"\n",1))+String(L"\n",1);
+	}else{
+		t_manifest=t_manifest.Replace(String(L"|",1),String(L"\n",1))+String(L"\n",1);
+	}
+	bb_config_SetConfigVar2(String(L"ANDROID_LIBRARY_REFERENCE_1",27),t_ref1);
+	bb_config_SetConfigVar2(String(L"ANDROID_LIBRARY_REFERENCE_2",27),t_ref2);
+	bb_config_SetConfigVar2(String(L"ANDROID_MANIFEST_MAIN",21),t_manifest);
 	String t_admob_appid=bb_config_GetConfigVar(String(L"ADMOB_ANDROID_ADS_APPID",23));
 	if(t_admob_appid.Length()>0){
 		String t_admob_appid2=String(L"<meta-data android:name=\"com.google.android.gms.ads.APPLICATION_ID\" ",68);

--- a/src/transcc/transcc.cxs
+++ b/src/transcc/transcc.cxs
@@ -22,7 +22,7 @@ Import builders
         Return False
     End
 #Else
-    Const VERSION:="2023-04-06"
+    Const VERSION:="2023-07-08"
 #Endif
 
 Function Main()


### PR DESCRIPTION
This is dawlanes' quick fix for the [separator issue](https://www.cerberus-x.com/community/index.php?threads/android_manifest-config-operator-not-working.1742/) where the add-assign operator results in pipe characters showing up instead of new line characters in AndroidManifest. 
It is an isolated fix for this case and doesn't solve potential issues with other config vars. The current handling breaks when there are "|" or ";" used inside of config vars which would be totally fine and useful for XML or build.gradle files for example.
