### PR TITLE
Restored config delimiter, GetConfigVar update, transcc debug mode test updates. 

### DIFF
--- a/modules/trans/config.cxs
+++ b/modules/trans/config.cxs
@@ -71,10 +71,11 @@ End
 
 ' Overloaded GetConfigVar.
 Function GetConfigVar$( key$, option$, replace$=" ")
-	Local str:=""
-	For Local i:=Eachin _cfgScope.vars.Get( key )
-		' TODO: Once all builders are updated to use the record separator the check for the pipe character can be removed.
-		If i="|"[0] Or i=option[0] Or i="~u001E"[0] str+=replace Else str+=String.FromChar(i)
+	Local str:="", value:=_cfgScope.vars.Get( key )
+	For Local i:=0 Until value.Length()
+		Local char:=value[i]
+		' TODO: Workout how to switch to using the record separator for CX internals.
+		If char="|"[0] Or char=option[0] Or char="~u001E"[0] str+=replace Else str+=String.FromChar(char)
 	Next
 	Return str
 End

--- a/modules/trans/preprocessor.cxs
+++ b/modules/trans/preprocessor.cxs
@@ -315,9 +315,9 @@ Function PreProcess$( path$,mdecl:ModuleDecl=Null )
 											If var="1" var="True" Else var="False"
 										Endif
 										
-										'If var And Not val.StartsWith( ";" ) val=";"+val
-										'If var And Not val.StartsWith( "|" ) val="|"+val
-										If var And Not val.StartsWith( "~u001E" ) val="~u001E"+val
+										If var And Not val.StartsWith( "|" ) val="|"+val
+										' TODO: Workout how to switch to using the record separator for CX internals.
+										'If var And Not val.StartsWith( "~u001E" ) val="~u001E"+val
 										SetConfigVar toke,var+val
 								End
 							

--- a/src/transcc/builders/android.cxs
+++ b/src/transcc/builders/android.cxs
@@ -10,7 +10,9 @@ Class AndroidBuilder Extends Builder
 	Method Config:String()
 		Local config:=New StringStack
 		For Local kv:=Eachin GetConfigVars()
-			config.Push "static final String "+kv.Key+"="+Enquote( kv.Value,"java" )+";"
+			' config.Push "static final String "+kv.Key+"="+Enquote( kv.Value,"java" )+";"
+			' Trim leading and trailling white space.
+			config.Push "static final String "+kv.Key+"="+Enquote( kv.Value().Trim(),"java" )+";"
 		Next
 		Return config.Join( "~n" )
 	End

--- a/src/transcc/debugconf.cxs
+++ b/src/transcc/debugconf.cxs
@@ -1,0 +1,122 @@
+' Defaults
+Const TEST_BUILD:="-run"
+
+#If DEBUG_TEST_CFG="Release"
+	Const TEST_CONFIG:="release"
+#Elseif DEBUG_TEST_CFG="Debug"
+	Const TEST_CONFIG:="debug"
+#Else
+#Error "DEBUG_TEST_CFG must be either Release or Debug and not "+DEBUG_TEST_CFG
+#Endif
+
+#If DEBUG_TARGET="Desktop"
+	#If DEBUG_TEST="TransCC"
+	    Const TEST_PATH:="/src/transcc/transcc_test/"
+	    Const TEST_FILE:="cpptool"
+	    Const TEST_TARGET:="C++_Tool"
+	    
+	 #Elseif DEBUG_TEST="Mojo"
+	 	Const TEST_PATH:="/examples/mojo/mak/"
+	    Const TEST_FILE:="bouncyaliens"
+	    Const TEST_TARGET:="Desktop_Game"
+	    
+	 #Elseif DEBUG_TEST="Mojo2"
+	 	Const TEST_PATH:="/examples/mojo2/"
+	    Const TEST_FILE:="bouncyaliens"
+	    Const TEST_TARGET:="Desktop_Game"
+	    
+	 #Elseif DEBUG_TEST="Reflection"
+	 	Const TEST_PATH:="/examples/reflection/"
+	    Const TEST_FILE:="reflectiontest"
+	    Const TEST_TARGET:="Desktop_Game"
+	    
+	 #Elseif DEBUG_TEST="Audio"
+	 	Const TEST_PATH:="/examples/mojo/mak/"
+	    Const TEST_FILE:="audiotest"
+	    Const TEST_TARGET:="Desktop_Game"
+	    
+	 #Else
+	 	#Error "DEBUG_TEST: Desktop must be Transcc,Mojo,Mojo2,Reflection or Audio and not "+DEBUG_TEST
+	 #Endif
+#Elseif DEBUG_TARGET="Android"
+	#If DEBUG_TEST="Mojo"
+	 	Const TEST_PATH:="/examples/mojo/mak/"
+	    Const TEST_FILE:="bouncyaliens"
+	    Const TEST_TARGET:="Android_Game"
+	    
+	 #Elseif DEBUG_TEST="Mojo2"
+	 	Const TEST_PATH:="/examples/mojo2/"
+	    Const TEST_FILE:="bouncyaliens"
+	    Const TEST_TARGET:="Android_Game"
+	    
+	 #Elseif DEBUG_TEST="Audio"
+	 	Const TEST_PATH:="/examples/mojo/mak/"
+	    Const TEST_FILE:="audiotest"
+	    Const TEST_TARGET:="Android_Game"
+	 #Else
+	 	#Error "DEBUG_TEST: Android must be Mojo,Mojo2 or Audio and not "+DEBUG_TEST
+	 #Endif
+#Elseif DEBUG_TARGET="iOS"
+	#If DEBUG_TEST="Mojo"
+	 	Const TEST_PATH:="/examples/mojo/mak/"
+	    Const TEST_FILE:="bouncyaliens"
+	    Const TEST_TARGET:="iOS_Game"
+	    
+	 #Elseif DEBUG_TEST="Mojo2"
+	 	Const TEST_PATH:="/examples/mojo2/"
+	    Const TEST_FILE:="bouncyaliens"
+	    Const TEST_TARGET:="iOS_Game"
+	    
+	 #Elseif DEBUG_TEST="Audio"
+	 	Const TEST_PATH:="/examples/mojo/mak/"
+	    Const TEST_FILE:="audiotest"
+	    Const TEST_TARGET:="iOS_Game"
+	 #Else
+	 	#Error "DEBUG_TEST: iOS must be Mojo, Mojo2 or Audio and not "+DEBUG_TEST
+	 #Endif
+#Elseif DEBUG_TARGET="iOS Metal"
+	#If DEBUG_TEST="Mojo"
+	 	Const TEST_PATH:="/examples/mojo/mak/"
+	    Const TEST_FILE:="bouncyaliens"
+	    Const TEST_TARGET:="iOS_Metal_Game"
+	    
+	 #Elseif DEBUG_TEST="Mojo2"
+	 	Const TEST_PATH:="/examples/mojo2/"
+	    Const TEST_FILE:="bouncyaliens"
+	    Const TEST_TARGET:="iOS_Metal_Game"
+	    
+	 #Elseif DEBUG_TEST="Audio"
+	 	Const TEST_PATH:="/examples/mojo/mak/"
+	    Const TEST_FILE:="audiotest"
+	    Const TEST_TARGET:="iOS_Metal_Game"
+	 #Else
+	 	#Error "DEBUG_TEST: iOS must be Mojo, Mojo2 or Audio and not "+DEBUG_TEST
+	 #Endif
+#Elseif DEBUG_TARGET="HTML"
+	#If DEBUG_TEST="Mojo"
+	 	Const TEST_PATH:="/examples/mojo/mak/"
+	    Const TEST_FILE:="bouncyaliens"
+	    Const TEST_TARGET:="Html5_Game"
+	    
+	 #Elseif DEBUG_TEST="Mojo2"
+	 	Const TEST_PATH:="/examples/mojo2/"
+	    Const TEST_FILE:="bouncyaliens"
+	    Const TEST_TARGET:="Html5_Game"
+	    
+	 #Elseif DEBUG_TEST="Audio"
+	 	Const TEST_PATH:="/examples/mojo/mak/"
+	    Const TEST_FILE:="audiotest"
+	    Const TEST_TARGET:="Html5_Game"
+	 #Else
+	 	#Error "DEBUG_TEST: HTML must be Mojo, Mojo2 or Audio and not "+DEBUG_TEST
+	 #Endif
+#Else
+	#Error "DEBUG_TARGET: Must be Desktop,Android,iOS or HTML and not "+DEBUG_TARGET
+#Endif
+
+' Comes in handy when needing to debug the parser.
+' If DebugIsMainCXS(Toker.Path) DebugStop
+Function DebugIsMainCXS( path:String )
+    If path.Contains( TEST_FILE+".cxs" ) Return True
+    Return False
+End

--- a/src/transcc/transcc.cxs
+++ b/src/transcc/transcc.cxs
@@ -6,23 +6,20 @@
 Import trans
 Import builders
 
-' Debug transcc
 #If CONFIG="debug"
-    Const VERSION:="2023-09-16 (DEBUG)"
-    Const TEST_PATH:="/src/transcc/transcc_test/"
-    Const TEST_BUILD:="-run"
-    Const TEST_CONFIG:="release"
-    Const TEST_FILE:="cpptool"
-    Const TEST_TARGET:="C++_Tool"
-  
-    ' Comes in handy when needing to debug the parser.
-    ' If DebugIsMainCXS(Toker.Path) DebugStop
-    Function DebugIsMainCXS( path:String )
-        If path.Contains( TEST_FILE+".cxs" ) Return True
-        Return False
-    End
+	'	DEBUG_TEST_CFG: Release,Debug
+	'	DEBUG_TARGET: Desktop,Android,iOS,iOS Metal,HTML
+	'	DEBUG_TEST: TransCC,Reflection,Mojo,Mojo2,Audio
+		
+	' Change the preprocessor directives to select the example to run for debugging transcc
+	#DEBUG_TEST_CFG="Release"
+	#DEBUG_TEST="Audio"
+	#DEBUG_TARGET="HTML"
+	Import debugconf
+	
+	Const VERSION:="2023-09-25 (DEBUG)"
 #Else
-    Const VERSION:="2023-09-16"
+    Const VERSION:="2023-09-25"
 #Endif
 
 Function Main()


### PR DESCRIPTION
Restored the config delimiter back to the pipe character until a solution can be worked out how to use the record separator as the default.

Changed the overloaded GetConfigVar function to use For-Until instead of For-Each to do copying of the string during character replacement.

Updated the way transcc will build/run tests when transcc is built with the debug configuration.

In the Android builder where ConfigScope.vars (i.e GetConfigVars) is copied to the java source file, white space is remove from the leading and trailing parts. This should clear up any miscellaneous \n characters in config vars such as ANDROID_MANIFEST_MAIN when the value is empty.